### PR TITLE
Releng: temp release manager access for gracenng

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -48,8 +48,8 @@ groups:
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
+      - nng.grace@gmail.com
       - pal.nabarun95@gmail.com
-      - ramses.green.2@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
In preparation of the v1.27.0-rc.0 cut on Thursday, March 23rd. Add gracenng and remove @ramrodo

cc @cici37